### PR TITLE
Basic ActiveRecord-specific Jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 New Jobs:
 
+* db_fuel/active_record/find_or_insert
 * db_fuel/active_record/insert
 * db_fuel/active_record/update
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 New Jobs:
 
 * db_fuel/active_record/insert
+* db_fuel/active_record/update
 
 # 1.0.0 (November 18th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.1.0 (TBD)
+# 1.1.0 (Decmeber 1st, 2020)
 
 New Jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.0 (TBD)
+
+New Jobs:
+
+* db_fuel/active_record/insert
+
 # 1.0.0 (November 18th, 2020)
 
 Initial implementation.  Includes jobs:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Refer to the [Burner](https://github.com/bluemarblepayroll/burner) library for m
 
 ### ActiveRecord Jobs
 
-* **db_fuel/active_record/find_or_insert** [table_name, attributes, debug, primary_key, register, separator, timestamps, unique_attributes]: An extension of the `db_fuel/active_record/insert` job that adds an existence check before sql insertion. The  `unique_attributes` will be converted to WHERE clauses for performing the existence check.
-* **db_fuel/active_record/insert** [table_name, attributes, debug, primary_key, register, separator, timestamps]: This job can take the objects in a register and insert them into a database table.  Attributes defines which object properties to convert to SQL.  Refer to the class and constructor specification for more detail.
+* **db_fuel/active_record/find_or_insert** [table_name, attributes, debug, primary_key, register, separator, timestamps, unique_attributes]: An extension of the `db_fuel/active_record/insert` job that adds an existence check before SQL insertion. The  `unique_attributes` will be converted to WHERE clauses for performing the existence check.
+* **db_fuel/active_record/insert** [table_name, attributes, debug, primary_key, register, separator, timestamps]: This job can take the objects in a register and insert them into a database table.  If primary_key is specified then its key will be set to the primary key.  Note that composite primary keys are not supported.  Attributes defines which object properties to convert to SQL.  Refer to the class and constructor specification for more detail.
 * **db_fuel/active_record/update** [table_name, attributes, debug, register, separator, timestamps, unique_attributes]: This job can take the objects in a register and updates them within a database table.  Attributes defines which object properties to convert to SQL SET clauses while unique_attributes translate to WHERE clauses.  Refer to the class and constructor specification for more detail.
 
 ### Dbee Jobs
@@ -194,11 +194,12 @@ There should now be two new patients, AB0 and AB1, present in the table `patient
 Notes:
 
 * Since we specified the `primary_key`, the records' `id` attributes should be set to their respective primary key values.
+* Composite primary keys are not currently supported.
 * Set `debug: true` to print out each INSERT statement in the output (not for production use.)
 
 #### Inserting Only New Records
 
-Another job `db_fuel/active_record/find_or_insert` allows for an existence check to performed each insertion.  If a record is found then it will not insert the record.  If `primary_key` is set then the existence check will also still set the primary key on the payload's respective object. We can build on the above insert example for only inserting new patients if their chart_number is unique:
+Another job `db_fuel/active_record/find_or_insert` allows for an existence check to performed each insertion.  If a record is found then it will not insert the record.  If `primary_key` is set then the existence check will also still set the primary key on the payload's respective object.  Note that composite primary keys are not currently supported. We can build on the above insert example for only inserting new patients if their chart_number is unique:
 
 ````ruby
 pipeline = {

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Refer to the [Burner](https://github.com/bluemarblepayroll/burner) library for m
 ### ActiveRecord Jobs
 
 * **db_fuel/active_record/insert** [table_name, attributes, debug, primary_key, register, separator, timestamps]: This job can take the objects in a register and insert them into a database table.  Attributes defines which object properties to convert to SQL.  Refer to the class and constructor specification for more detail.
+* **db_fuel/active_record/update** [table_name, attributes, debug, register, separator, timestamps, unique_keys]: This job can take the objects in a register and updates them within a database table.  Attributes defines which object properties to convert to SQL SET clauses while unique_keys translate to WHERE clauses.  Refer to the class and constructor specification for more detail.
 
 ### Dbee Jobs
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ bundle add db_fuel
 
 Refer to the [Burner](https://github.com/bluemarblepayroll/burner) library for more specific information on how Burner works.  This section will just focus on what this library directly adds.
 
+### ActiveRecord Jobs
+
+* **db_fuel/active_record/insert** [table_name, attributes, debug, primary_key, register, separator, timestamps]: This job can take the objects in a register and insert them into a database table.  Attributes defines which object properties to convert to SQL.  Refer to the class and constructor specification for more detail.
+
+### Dbee Jobs
+
 * **db_fuel/dbee/query** [model, query, register]:  Pass in a [Dbee](https://github.com/bluemarblepayroll/dbee) model and query and store the results in the specified register.  Refer to the [Dbee](https://github.com/bluemarblepayroll/dbee) library directly on how to craft a model or query.
 * **db_fuel/dbee/range** [key, key_path, model, query, register, separator]: Similar to `db_fuel/dbee/query` with the addition of being able to grab a list of values from the register to use as a Dbee EQUALS/IN filter.  This helps to dynamically limit the resulting record set.  The key is used to specify where to grab the list of values, while the key_path will be used to craft the [Dbee equal's filter](https://github.com/bluemarblepayroll/dbee/blob/master/lib/dbee/query/filters/equals.rb).  Separator is exposed in case nested object support is necessary.
 

--- a/db_fuel.gemspec
+++ b/db_fuel.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activerecord', activerecord_version)
   s.add_dependency('acts_as_hashable', '~>1.2')
-  s.add_dependency('burner', '~>1.0')
+  s.add_dependency('burner', '~>1.2')
   s.add_dependency('dbee', '~>2.1')
   s.add_dependency('dbee-active_record', '~>2.1')
   s.add_dependency('objectable', '~>1.0')

--- a/lib/db_fuel.rb
+++ b/lib/db_fuel.rb
@@ -17,4 +17,7 @@ require 'objectable'
 # General purpose classes used by the main job classes.
 require_relative 'db_fuel/modeling'
 
+# Internal logic used across jobs.
+require_relative 'db_fuel/db_provider'
+
 require_relative 'db_fuel/library'

--- a/lib/db_fuel.rb
+++ b/lib/db_fuel.rb
@@ -14,4 +14,7 @@ require 'dbee'
 require 'dbee/providers/active_record_provider'
 require 'objectable'
 
+# General purpose classes used by the main job classes.
+require_relative 'db_fuel/modeling'
+
 require_relative 'db_fuel/library'

--- a/lib/db_fuel/db_provider.rb
+++ b/lib/db_fuel/db_provider.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module DbFuel
+  # Intermediate internal API for Arel/ActiveRecord.  There is some overlap in job needs when
+  # it comes to the Arel interface so this class condenses down those needs into this class.
+  class DbProvider # :nodoc: all
+    attr_reader :arel_table
+
+    def initialize(table_name)
+      raise ArgumentError, 'table_name is required' if table_name.to_s.empty?
+
+      @arel_table = ::Arel::Table.new(table_name.to_s)
+
+      freeze
+    end
+
+    def first(object)
+      sql = first_sql(object)
+
+      ::ActiveRecord::Base.connection.exec_query(sql).first
+    end
+
+    def first_sql(object)
+      relation = arel_table.project(Arel.star).take(1)
+      manager  = apply_where(object, relation)
+
+      manager.to_sql
+    end
+
+    def insert_sql(object)
+      insert_manager(object).to_sql
+    end
+
+    def insert(object)
+      manager = insert_manager(object)
+
+      ::ActiveRecord::Base.connection.insert(manager)
+    end
+
+    def update(set_object, where_object)
+      manager = update_manager(set_object, where_object)
+
+      ::ActiveRecord::Base.connection.update(manager)
+    end
+
+    def update_sql(set_object, where_object)
+      update_manager(set_object, where_object).to_sql
+    end
+
+    private
+
+    def update_manager(set_object, where_object)
+      arel_row       = make_arel_row(set_object)
+      update_manager = ::Arel::UpdateManager.new.set(arel_row).table(arel_table)
+
+      apply_where(where_object, update_manager)
+    end
+
+    def apply_where(hash, manager)
+      (hash || {}).inject(manager) do |memo, (key, value)|
+        memo.where(arel_table[key].eq(value))
+      end
+    end
+
+    def insert_manager(object)
+      arel_row = make_arel_row(object)
+
+      ::Arel::InsertManager.new.insert(arel_row)
+    end
+
+    def make_arel_row(row)
+      row.map { |key, value| [arel_table[key], value] }
+    end
+  end
+end

--- a/lib/db_fuel/library.rb
+++ b/lib/db_fuel/library.rb
@@ -7,12 +7,16 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+require_relative 'library/active_record/insert'
+
 require_relative 'library/dbee/query'
 require_relative 'library/dbee/range'
 
 module Burner
   # Open up Burner::Jobs and add registrations for this libraries jobs.
   class Jobs
+    register 'db_fuel/active_record/insert', DbFuel::Library::ActiveRecord::Insert
+
     register 'db_fuel/dbee/query', DbFuel::Library::Dbee::Query
     register 'db_fuel/dbee/range', DbFuel::Library::Dbee::Range
   end

--- a/lib/db_fuel/library.rb
+++ b/lib/db_fuel/library.rb
@@ -8,6 +8,7 @@
 #
 
 require_relative 'library/active_record/insert'
+require_relative 'library/active_record/update'
 
 require_relative 'library/dbee/query'
 require_relative 'library/dbee/range'
@@ -16,6 +17,7 @@ module Burner
   # Open up Burner::Jobs and add registrations for this libraries jobs.
   class Jobs
     register 'db_fuel/active_record/insert', DbFuel::Library::ActiveRecord::Insert
+    register 'db_fuel/active_record/update', DbFuel::Library::ActiveRecord::Update
 
     register 'db_fuel/dbee/query', DbFuel::Library::Dbee::Query
     register 'db_fuel/dbee/range', DbFuel::Library::Dbee::Range

--- a/lib/db_fuel/library.rb
+++ b/lib/db_fuel/library.rb
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+require_relative 'library/active_record/find_or_insert'
 require_relative 'library/active_record/insert'
 require_relative 'library/active_record/update'
 
@@ -16,10 +17,11 @@ require_relative 'library/dbee/range'
 module Burner
   # Open up Burner::Jobs and add registrations for this libraries jobs.
   class Jobs
-    register 'db_fuel/active_record/insert', DbFuel::Library::ActiveRecord::Insert
-    register 'db_fuel/active_record/update', DbFuel::Library::ActiveRecord::Update
+    register 'db_fuel/active_record/find_or_insert', DbFuel::Library::ActiveRecord::FindOrInsert
+    register 'db_fuel/active_record/insert',         DbFuel::Library::ActiveRecord::Insert
+    register 'db_fuel/active_record/update',         DbFuel::Library::ActiveRecord::Update
 
-    register 'db_fuel/dbee/query', DbFuel::Library::Dbee::Query
-    register 'db_fuel/dbee/range', DbFuel::Library::Dbee::Range
+    register 'db_fuel/dbee/query',                   DbFuel::Library::Dbee::Query
+    register 'db_fuel/dbee/range',                   DbFuel::Library::Dbee::Range
   end
 end

--- a/lib/db_fuel/library/active_record/base.rb
+++ b/lib/db_fuel/library/active_record/base.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module DbFuel
+  module Library
+    module ActiveRecord
+      # This job can take the objects in a register and insert them into a database table.
+      #
+      # Expected Payload[register] input: array of objects
+      # Payload[register] output: array of objects.
+      class Base < Burner::JobWithRegister
+        CREATED_AT = :created_at
+        NOW_TYPE   = 'r/value/now'
+        UPDATED_AT = :updated_at
+
+        attr_reader :arel_table,
+                    :attribute_renderers,
+                    :debug,
+                    :resolver
+
+        def initialize(
+          name:,
+          table_name:,
+          attributes: [],
+          debug: false,
+          register: Burner::DEFAULT_REGISTER,
+          separator: ''
+        )
+          super(name: name, register: register)
+
+          @arel_table = ::Arel::Table.new(table_name.to_s)
+          @debug      = debug || false
+
+          # set resolver first since make_attribute_renderers needs it.
+          @resolver = Objectable.resolver(separator: separator)
+
+          @attribute_renderers = Burner::Modeling::Attribute
+                                 .array(attributes)
+                                 .map { |a| Burner::Modeling::AttributeRenderer.new(a, resolver) }
+        end
+
+        private
+
+        def timestamp_attribute(key)
+          Burner::Modeling::Attribute.make(
+            key: key,
+            transformers: [
+              { type: NOW_TYPE }
+            ]
+          )
+        end
+
+        def debug_detail(output, message)
+          return unless debug
+
+          output.detail(message)
+        end
+
+        def make_arel_row(row)
+          row.map { |key, value| [arel_table[key], value] }
+        end
+
+        def transform(row, time)
+          attribute_renderers.each_with_object({}) do |attribute_renderer, memo|
+            value = attribute_renderer.transform(row, time)
+
+            resolver.set(memo, attribute_renderer.key, value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/db_fuel/library/active_record/find_or_insert.rb
+++ b/lib/db_fuel/library/active_record/find_or_insert.rb
@@ -29,7 +29,7 @@ module DbFuel
         #
         #   attributes:  Used to specify which object properties to put into the
         #                SQL statement and also allows for one last custom transformation
-        #                pipeline, in case the data calls for sql-specific transformers
+        #                pipeline, in case the data calls for SQL-specific transformers
         #                before insertion.
         #
         #   debug: If debug is set to true (defaults to false) then the SQL statements and

--- a/lib/db_fuel/library/active_record/insert.rb
+++ b/lib/db_fuel/library/active_record/insert.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module DbFuel
+  module Library
+    module ActiveRecord
+      # This job can take the objects in a register and insert them into a database table.
+      #
+      # Expected Payload[register] input: array of objects
+      # Payload[register] output: array of objects.
+      class Insert < Burner::JobWithRegister
+        attr_reader :arel_table,
+                    :attribute_renderers,
+                    :debug,
+                    :primary_key,
+                    :resolver
+
+        # Arguments:
+        #   name [required]: name of the job within the Burner::Pipeline.
+        #
+        #   table_name [required]: name of the table to use for the INSERT statements.
+        #
+        #   attributes:  Used to specify which object properties to put into the
+        #                SQL statement and also allows for one last custom transformation
+        #                pipeline, in case the data calls for sql-specific transformers
+        #                before insertion.
+        #
+        #   debug: If debug is set to true (defaults to false) then the SQL statements and
+        #          returned objects will be printed in the output.  Only use this option while
+        #          debugging issues as it will fill up the output with (potentially too much) data.
+        #
+        #   primary_key: If primary_key is present then it will be used to set the object's
+        #                property to the returned primary key from the INSERT statement.
+        #
+        #   separator: Just like other jobs with a 'separator' option, if the objects require
+        #              key-path notation or nested object support, you can set the separator
+        #              to something non-blank (like a period for notation in the
+        #              form of: name.first).
+        #
+        #   timestamps: If timestamps is true (default behavior) then both created_at
+        #               and updated_at columns will  automatically have their values set
+        #               to the current UTC timestamp.
+        def initialize(
+          name:,
+          table_name:,
+          attributes: [],
+          debug: false,
+          primary_key: nil,
+          register: Burner::DEFAULT_REGISTER,
+          separator: '',
+          timestamps: true
+        )
+          super(name: name, register: register)
+
+          # set resolver first since make_attribute_renderers needs it.
+          @resolver = Objectable.resolver(separator: separator)
+
+          @arel_table          = ::Arel::Table.new(table_name.to_s)
+          @attribute_renderers = make_attribute_renderers(attributes, timestamps)
+          @debug               = debug || false
+          @primary_key         = Modeling::KeyedColumn.make(primary_key, nullable: true)
+
+          freeze
+        end
+
+        def perform(output, payload)
+          payload[register] = array(payload[register])
+
+          payload[register].each do |row|
+            arel_row = make_arel_row(transform(row, payload.time))
+
+            insert_manager = ::Arel::InsertManager.new
+            insert_manager.insert(arel_row)
+
+            output.detail("Insert Statement: #{insert_manager.to_sql}")
+
+            id = ::ActiveRecord::Base.connection.insert(insert_manager)
+
+            resolver.set(row, primary_key.key, id) if primary_key
+
+            output.detail("Insert Return: #{row}")
+          end
+        end
+
+        private
+
+        def timestamp_renderers
+          Burner::Modeling::Attribute.array(
+            [
+              {
+                key: :created_at,
+                transformers: [
+                  { type: 'r/value/now' }
+                ]
+              },
+              {
+                key: :updated_at,
+                transformers: [
+                  { type: 'r/value/now' }
+                ]
+              }
+            ]
+          ).map { |a| Burner::Modeling::AttributeRenderer.new(a, resolver) }
+        end
+
+        def make_attribute_renderers(attributes, timestamps)
+          renderers = Burner::Modeling::Attribute
+                      .array(attributes)
+                      .map { |a| Burner::Modeling::AttributeRenderer.new(a, resolver) }
+
+          timestamps ? renderers + timestamp_renderers : renderers
+        end
+
+        def make_arel_row(row)
+          row.map { |key, value| [arel_table[key], value] }
+        end
+
+        def transform(row, time)
+          attribute_renderers.each_with_object({}) do |attribute_renderer, memo|
+            value = attribute_renderer.transform(row, time)
+
+            resolver.set(memo, attribute_renderer.key, value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/db_fuel/library/active_record/insert.rb
+++ b/lib/db_fuel/library/active_record/insert.rb
@@ -15,6 +15,10 @@ module DbFuel
       # Expected Payload[register] input: array of objects
       # Payload[register] output: array of objects.
       class Insert < Burner::JobWithRegister
+        CREATED_AT = :created_at
+        NOW_TYPE   = 'r/value/now'
+        UPDATED_AT = :updated_at
+
         attr_reader :arel_table,
                     :attribute_renderers,
                     :debug,
@@ -78,31 +82,37 @@ module DbFuel
             insert_manager = ::Arel::InsertManager.new
             insert_manager.insert(arel_row)
 
-            output.detail("Insert Statement: #{insert_manager.to_sql}")
+            debug_detail(output, "Insert Statement: #{insert_manager.to_sql}")
 
             id = ::ActiveRecord::Base.connection.insert(insert_manager)
 
             resolver.set(row, primary_key.key, id) if primary_key
 
-            output.detail("Insert Return: #{row}")
+            debug_detail(output, "Insert Return: #{row}")
           end
         end
 
         private
 
+        def debug_detail(output, message)
+          return unless debug
+
+          output.detail(message)
+        end
+
         def timestamp_renderers
           Burner::Modeling::Attribute.array(
             [
               {
-                key: :created_at,
+                key: CREATED_AT,
                 transformers: [
-                  { type: 'r/value/now' }
+                  { type: NOW_TYPE }
                 ]
               },
               {
-                key: :updated_at,
+                key: UPDATED_AT,
                 transformers: [
-                  { type: 'r/value/now' }
+                  { type: NOW_TYPE }
                 ]
               }
             ]

--- a/lib/db_fuel/library/active_record/insert.rb
+++ b/lib/db_fuel/library/active_record/insert.rb
@@ -26,7 +26,7 @@ module DbFuel
         #
         #   attributes:  Used to specify which object properties to put into the
         #                SQL statement and also allows for one last custom transformation
-        #                pipeline, in case the data calls for sql-specific transformers
+        #                pipeline, in case the data calls for SQL-specific transformers
         #                before insertion.
         #
         #   debug: If debug is set to true (defaults to false) then the SQL statements and

--- a/lib/db_fuel/library/active_record/update.rb
+++ b/lib/db_fuel/library/active_record/update.rb
@@ -28,7 +28,7 @@ module DbFuel
         #
         #   attributes:  Used to specify which object properties to put into the
         #                SQL statement and also allows for one last custom transformation
-        #                pipeline, in case the data calls for sql-specific transformers
+        #                pipeline, in case the data calls for SQL-specific transformers
         #                before mutation.
         #
         #   debug: If debug is set to true (defaults to false) then the SQL statements and

--- a/lib/db_fuel/library/active_record/update.rb
+++ b/lib/db_fuel/library/active_record/update.rb
@@ -12,12 +12,14 @@ require_relative 'base'
 module DbFuel
   module Library
     module ActiveRecord
-      # This job can take the objects in a register and insert them into a database table.
+      # This job can take the objects in a register and updates them within database table.
+      # The attributes translate to SQL SET clauses and the unique_keys translate to
+      # WHERE clauses.
       #
       # Expected Payload[register] input: array of objects
       # Payload[register] output: array of objects.
-      class Insert < Base
-        attr_reader :primary_key
+      class Update < Base
+        attr_reader :unique_keys
 
         # Arguments:
         #   name [required]: name of the job within the Burner::Pipeline.
@@ -27,32 +29,31 @@ module DbFuel
         #   attributes:  Used to specify which object properties to put into the
         #                SQL statement and also allows for one last custom transformation
         #                pipeline, in case the data calls for sql-specific transformers
-        #                before insertion.
+        #                before mutation.
         #
         #   debug: If debug is set to true (defaults to false) then the SQL statements and
         #          returned objects will be printed in the output.  Only use this option while
         #          debugging issues as it will fill up the output with (potentially too much) data.
-        #
-        #   primary_key: If primary_key is present then it will be used to set the object's
-        #                property to the returned primary key from the INSERT statement.
         #
         #   separator: Just like other jobs with a 'separator' option, if the objects require
         #              key-path notation or nested object support, you can set the separator
         #              to something non-blank (like a period for notation in the
         #              form of: name.first).
         #
-        #   timestamps: If timestamps is true (default behavior) then both created_at
-        #               and updated_at columns will automatically have their values set
-        #               to the current UTC timestamp.
+        #   timestamps: If timestamps is true (default behavior) then the updated_at column will
+        #               automatically have its value set to the current UTC timestamp.
+        #
+        #   unique_keys: Each key will become a WHERE clause in order to only update specific
+        #                records.
         def initialize(
           name:,
           table_name:,
           attributes: [],
           debug: false,
-          primary_key: nil,
           register: Burner::DEFAULT_REGISTER,
           separator: '',
-          timestamps: true
+          timestamps: true,
+          unique_keys: []
         )
           explicit_attributes = Burner::Modeling::Attribute.array(attributes)
 
@@ -67,35 +68,55 @@ module DbFuel
             separator: separator
           )
 
-          @primary_key = Modeling::KeyedColumn.make(primary_key, nullable: true)
+          @unique_keys = Modeling::KeyedColumn.array(unique_keys)
 
           freeze
         end
 
         def perform(output, payload)
+          total_rows_affected = 0
+
           payload[register] = array(payload[register])
 
           payload[register].each do |row|
-            arel_row       = make_arel_row(transform(row, payload.time))
-            insert_manager = ::Arel::InsertManager.new.insert(arel_row)
+            update_manager = make_update_manager(row, payload.time)
 
-            debug_detail(output, "Insert Statement: #{insert_manager.to_sql}")
+            debug_detail(output, "Update Statement: #{update_manager.to_sql}")
 
-            id = ::ActiveRecord::Base.connection.insert(insert_manager)
+            rows_affected = ::ActiveRecord::Base.connection.update(update_manager)
 
-            resolver.set(row, primary_key.key, id) if primary_key
+            debug_detail(output, "Individual Rows Affected: #{rows_affected}")
 
-            debug_detail(output, "Insert Return: #{row}")
+            total_rows_affected += rows_affected
           end
+
+          output.detail("Total Rows Affected: #{total_rows_affected}")
         end
 
         private
 
+        def make_update_manager(row, time)
+          arel_row       = make_arel_row(transform(row, time))
+          unique_values  = make_unique_column_values(row)
+          update_manager = ::Arel::UpdateManager.new.set(arel_row).table(arel_table)
+
+          apply_where(unique_values, update_manager)
+        end
+
+        def make_unique_column_values(row)
+          unique_keys.each_with_object({}) do |unique_key, memo|
+            memo[unique_key.column] = resolver.get(row, unique_key.key)
+          end
+        end
+
+        def apply_where(hash, manager)
+          (hash || {}).inject(manager) do |memo, (key, value)|
+            memo.where(arel_table[key].eq(value))
+          end
+        end
+
         def timestamp_attributes
-          [
-            timestamp_attribute(CREATED_AT),
-            timestamp_attribute(UPDATED_AT)
-          ]
+          [timestamp_attribute(UPDATED_AT)]
         end
       end
     end

--- a/lib/db_fuel/modeling.rb
+++ b/lib/db_fuel/modeling.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require_relative 'modeling/keyed_column'

--- a/lib/db_fuel/modeling/keyed_column.rb
+++ b/lib/db_fuel/modeling/keyed_column.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module DbFuel
+  module Modeling
+    # Connects a hash key to a sql column.  By default if a column is not given then its
+    # key will be used for both.  The general use case for this is for mapping objects
+    # to sql and sql to objects.
+    class KeyedColumn
+      acts_as_hashable
+
+      attr_reader :column, :key
+
+      def initialize(key:, column: '')
+        raise ArgumentError, 'key is required' if key.blank?
+
+        @column = column.present? ? column.to_s : key.to_s
+        @key    = key.to_s
+
+        freeze
+      end
+    end
+  end
+end

--- a/lib/db_fuel/modeling/keyed_column.rb
+++ b/lib/db_fuel/modeling/keyed_column.rb
@@ -9,9 +9,9 @@
 
 module DbFuel
   module Modeling
-    # Connects a hash key to a sql column.  By default if a column is not given then its
+    # Connects a hash key to a SQL column.  By default if a column is not given then its
     # key will be used for both.  The general use case for this is for mapping objects
-    # to sql and sql to objects.
+    # to SQL and SQL to objects.
     class KeyedColumn
       acts_as_hashable
 

--- a/lib/db_fuel/version.rb
+++ b/lib/db_fuel/version.rb
@@ -8,5 +8,5 @@
 #
 
 module DbFuel
-  VERSION = '1.1.0-alpha.1'
+  VERSION = '1.1.0'
 end

--- a/lib/db_fuel/version.rb
+++ b/lib/db_fuel/version.rb
@@ -8,5 +8,5 @@
 #
 
 module DbFuel
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/lib/db_fuel/version.rb
+++ b/lib/db_fuel/version.rb
@@ -8,5 +8,5 @@
 #
 
 module DbFuel
-  VERSION = '1.1.0-alpha'
+  VERSION = '1.1.0-alpha.1'
 end

--- a/lib/db_fuel/version.rb
+++ b/lib/db_fuel/version.rb
@@ -8,5 +8,5 @@
 #
 
 module DbFuel
-  VERSION = '1.1.0'
+  VERSION = '1.1.0-alpha'
 end

--- a/spec/db_fuel/library/active_record/find_or_insert_spec.rb
+++ b/spec/db_fuel/library/active_record/find_or_insert_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+describe DbFuel::Library::ActiveRecord::FindOrInsert do
+  before(:each) do
+    load_data
+  end
+
+  let(:output)   { make_burner_output }
+  let(:register) { 'register_a' }
+  let(:debug)    { false }
+
+  let(:config) do
+    {
+      name: 'test_job',
+      register: register,
+      debug: debug,
+      attributes: [
+        { key: :chart_number },
+        { key: :first_name },
+        { key: :last_name }
+      ],
+      table_name: 'patients',
+      primary_key: { key: :id },
+      unique_attributes: [
+        { key: :chart_number }
+      ]
+    }
+  end
+
+  let(:patients) do
+    [
+      # Should be finds based on chart_number
+      { 'chart_number' => 'C0001', 'first_name' => 'BOZZY',  'last_name' => 'CLOWNZY' },
+      { 'chart_number' => 'R0001', 'first_name' => 'FRANKY', 'last_name' => 'RIZZY' },
+
+      # Should be inserts based on chart_number
+      { 'chart_number' => 'G0001', 'first_name' => 'HAPPY',  'last_name' => 'GILMORE' },
+      { 'chart_number' => 'M0001', 'first_name' => 'BILLY',  'last_name' => 'MADISON' }
+    ]
+  end
+
+  let(:payload) do
+    Burner::Payload.new(
+      registers: {
+        register => patients.map { |p| {}.merge(p) } # shallow copy to preserve original
+      }
+    )
+  end
+
+  let(:written) { output.outs.first.string }
+
+  subject { described_class.make(config) }
+
+  describe '#perform' do
+    before(:each) do
+      subject.perform(output, payload)
+    end
+
+    it 'inserts new records' do
+      actual = Patient
+               .order(:chart_number)
+               .select(:chart_number, :first_name, :last_name)
+               .as_json(except: :id)
+
+      expected = [
+        { 'chart_number' => 'B0001', 'first_name' => 'Bugs', 'last_name' => 'Bunny' },
+        { 'chart_number' => 'C0001', 'first_name' => 'Bozo', 'last_name' => 'Clown' },
+        { 'chart_number' => 'G0001', 'first_name' => 'HAPPY', 'last_name' => 'GILMORE' },
+        { 'chart_number' => 'M0001', 'first_name' => 'BILLY', 'last_name' => 'MADISON' },
+        { 'chart_number' => 'R0001', 'first_name' => 'Frank', 'last_name' => 'Rizzo' }
+      ]
+
+      expect(actual.count).to eq(5)
+      expect(actual).to       eq(expected)
+    end
+
+    it 'outputs total existed count' do
+      expect(output.outs.first.string).to include('Total Existed: 2')
+    end
+
+    it 'outputs total inserted count' do
+      expect(output.outs.first.string).to include('Total Inserted: 2')
+    end
+
+    it 'sets primary_key for all payload objects' do
+      payload[register].each do |object|
+        expected = Patient.find_by(chart_number: object['chart_number']).id
+        actual   = object['id']
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'when debug is true' do
+      let(:debug) { true }
+
+      it 'outputs find sql' do
+        expect(written).to include('Find Statement: SELECT * FROM "patients"')
+      end
+
+      it 'outputs existing record' do
+        expect(written).to include('Record Exists: {')
+      end
+    end
+  end
+end

--- a/spec/db_fuel/library/active_record/find_or_insert_spec.rb
+++ b/spec/db_fuel/library/active_record/find_or_insert_spec.rb
@@ -104,7 +104,7 @@ describe DbFuel::Library::ActiveRecord::FindOrInsert do
       let(:debug) { true }
 
       it 'outputs find sql' do
-        expect(written).to include('Find Statement: SELECT * FROM "patients"')
+        expect(written).to include('Find Statement: SELECT')
       end
 
       it 'outputs existing record' do

--- a/spec/db_fuel/library/active_record/insert_spec.rb
+++ b/spec/db_fuel/library/active_record/insert_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+describe DbFuel::Library::ActiveRecord::Insert do
+  let(:output)   { make_burner_output }
+  let(:register) { 'register_a' }
+  let(:debug)    { false }
+
+  let(:config) do
+    {
+      name: 'test_job',
+      register: register,
+      debug: debug,
+      attributes: [
+        {
+          key: :chart_number,
+          transformers: [
+            {
+              type: 'r/value/resolve',
+              key: :chart_number
+            }
+          ]
+        },
+        {
+          key: :first_name,
+          transformers: [
+            {
+              type: 'r/value/resolve',
+              key: :first_name
+            }
+          ]
+        },
+        {
+          key: :last_name,
+          transformers: [
+            {
+              type: 'r/value/resolve',
+              key: :last_name
+            }
+          ]
+        }
+
+      ],
+      table_name: 'patients',
+      primary_key: {
+        key: :id
+      }
+    }
+  end
+
+  let(:patients) do
+    [
+      { chart_number: 'AB0', first_name: 'a0', last_name: 'b0' },
+      { chart_number: 'AB1', first_name: 'a1', last_name: 'b1' }
+    ]
+  end
+
+  let(:payload) do
+    Burner::Payload.new(
+      registers: {
+        register => patients
+      }
+    )
+  end
+
+  subject { described_class.make(config) }
+
+  describe '#perform' do
+    before(:each) do
+      subject.perform(output, payload)
+    end
+
+    context 'when debug is true' do
+      let(:debug)   { true }
+      let(:written) { output.outs.first.string }
+
+      it 'outputs sql statements' do
+        expect(written).to include('Insert Statement: INSERT INTO "patients"')
+      end
+
+      it 'outputs return object' do
+        expect(written).to include('Insert Return: {')
+      end
+    end
+
+    it 'inserts records with specified attributes' do
+      db_patients = Patient.order(:chart_number)
+
+      expect(db_patients.count).to eq(2)
+
+      db_patients.each_with_index do |db_patient, index|
+        expect(db_patient.chart_number).to eq(patients.dig(index, :chart_number))
+        expect(db_patient.first_name).to   eq(patients.dig(index, :first_name))
+        expect(db_patient.last_name).to    eq(patients.dig(index, :last_name))
+      end
+    end
+  end
+end

--- a/spec/db_fuel/library/active_record/insert_spec.rb
+++ b/spec/db_fuel/library/active_record/insert_spec.rb
@@ -91,6 +91,18 @@ describe DbFuel::Library::ActiveRecord::Insert do
       end
     end
 
+    context 'when debug is false' do
+      let(:written) { output.outs.first.string }
+
+      it 'output does not contain sql statements' do
+        expect(written).not_to include('Insert Statement: INSERT INTO "patients"')
+      end
+
+      it 'output doesn not contain return object' do
+        expect(written).not_to include('Insert Return: {')
+      end
+    end
+
     it 'inserts records with specified attributes' do
       db_patients = Patient.order(:chart_number)
 

--- a/spec/db_fuel/library/active_record/insert_spec.rb
+++ b/spec/db_fuel/library/active_record/insert_spec.rb
@@ -20,34 +20,9 @@ describe DbFuel::Library::ActiveRecord::Insert do
       register: register,
       debug: debug,
       attributes: [
-        {
-          key: :chart_number,
-          transformers: [
-            {
-              type: 'r/value/resolve',
-              key: :chart_number
-            }
-          ]
-        },
-        {
-          key: :first_name,
-          transformers: [
-            {
-              type: 'r/value/resolve',
-              key: :first_name
-            }
-          ]
-        },
-        {
-          key: :last_name,
-          transformers: [
-            {
-              type: 'r/value/resolve',
-              key: :last_name
-            }
-          ]
-        }
-
+        { key: :chart_number },
+        { key: :first_name },
+        { key: :last_name }
       ],
       table_name: 'patients',
       primary_key: {
@@ -71,6 +46,8 @@ describe DbFuel::Library::ActiveRecord::Insert do
     )
   end
 
+  let(:written) { output.outs.first.string }
+
   subject { described_class.make(config) }
 
   describe '#perform' do
@@ -79,26 +56,23 @@ describe DbFuel::Library::ActiveRecord::Insert do
     end
 
     context 'when debug is true' do
-      let(:debug)   { true }
-      let(:written) { output.outs.first.string }
+      let(:debug) { true }
 
       it 'outputs sql statements' do
         expect(written).to include('Insert Statement: INSERT INTO "patients"')
       end
 
-      it 'outputs return object' do
+      it 'outputs return objects' do
         expect(written).to include('Insert Return: {')
       end
     end
 
     context 'when debug is false' do
-      let(:written) { output.outs.first.string }
-
-      it 'output does not contain sql statements' do
+      it 'does not output does sql statements' do
         expect(written).not_to include('Insert Statement: INSERT INTO "patients"')
       end
 
-      it 'output doesn not contain return object' do
+      it 'does not output return objects' do
         expect(written).not_to include('Insert Return: {')
       end
     end
@@ -112,6 +86,17 @@ describe DbFuel::Library::ActiveRecord::Insert do
         expect(db_patient.chart_number).to eq(patients.dig(index, :chart_number))
         expect(db_patient.first_name).to   eq(patients.dig(index, :first_name))
         expect(db_patient.last_name).to    eq(patients.dig(index, :last_name))
+      end
+    end
+
+    it 'sets timestamp columns' do
+      db_patients = Patient.order(:chart_number)
+
+      expect(db_patients.count).to eq(2)
+
+      db_patients.each_with_index do |db_patient, _index|
+        expect(db_patient.created_at).not_to be nil
+        expect(db_patient.updated_at).not_to be nil
       end
     end
   end

--- a/spec/db_fuel/library/active_record/insert_spec.rb
+++ b/spec/db_fuel/library/active_record/insert_spec.rb
@@ -58,7 +58,7 @@ describe DbFuel::Library::ActiveRecord::Insert do
     context 'when debug is true' do
       let(:debug) { true }
 
-      it 'outputs sql statements' do
+      it 'outputs SQL statements' do
         expect(written).to include('Insert Statement: INSERT INTO "patients"')
       end
 
@@ -68,7 +68,7 @@ describe DbFuel::Library::ActiveRecord::Insert do
     end
 
     context 'when debug is false' do
-      it 'does not output does sql statements' do
+      it 'does not output does SQL statements' do
         expect(written).not_to include('Insert Statement: INSERT INTO "patients"')
       end
 

--- a/spec/db_fuel/library/active_record/update_spec.rb
+++ b/spec/db_fuel/library/active_record/update_spec.rb
@@ -97,7 +97,7 @@ describe DbFuel::Library::ActiveRecord::Update do
     context 'when debug is true' do
       let(:debug) { true }
 
-      it 'outputs sql statements' do
+      it 'outputs SQL statements' do
         expect(written).to include('Update Statement: UPDATE "patients"')
       end
 
@@ -107,7 +107,7 @@ describe DbFuel::Library::ActiveRecord::Update do
     end
 
     context 'when debug is false' do
-      it 'does not output does sql statements' do
+      it 'does not output does SQL statements' do
         expect(written).not_to include('Update Statement: UPDATE "patients"')
       end
 

--- a/spec/db_fuel/library/active_record/update_spec.rb
+++ b/spec/db_fuel/library/active_record/update_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+describe DbFuel::Library::ActiveRecord::Update do
+  before(:each) do
+    load_data
+  end
+
+  let(:output)   { make_burner_output }
+  let(:register) { 'register_a' }
+  let(:debug)    { false }
+
+  let(:config) do
+    {
+      name: 'test_job',
+      register: register,
+      debug: debug,
+      attributes: [
+        { key: :first_name },
+        { key: :last_name }
+      ],
+      table_name: 'patients',
+      unique_keys: [
+        { key: :chart_number }
+      ]
+    }
+  end
+
+  let(:patients) do
+    [
+      { chart_number: 'C0001', first_name: 'BOZZY', last_name: 'CLOWNZY' },
+      { chart_number: 'R0001', first_name: 'FRANKY', last_name: 'RIZZY' }
+    ]
+  end
+
+  let(:chart_numbers) { patients.map { |p| p[:chart_number] } }
+
+  let(:payload) do
+    Burner::Payload.new(
+      registers: {
+        register => patients
+      }
+    )
+  end
+
+  let(:written) { output.outs.first.string }
+
+  subject { described_class.make(config) }
+
+  describe '#perform' do
+    before(:each) do
+      subject.perform(output, payload)
+    end
+
+    it 'updates scoped records with specified attributes' do
+      db_patients = Patient.order(:chart_number).where(chart_number: chart_numbers)
+
+      expect(db_patients.count).to eq(2)
+
+      db_patients.each_with_index do |db_patient, index|
+        expect(db_patient.chart_number).to eq(patients.dig(index, :chart_number))
+        expect(db_patient.first_name).to   eq(patients.dig(index, :first_name))
+        expect(db_patient.last_name).to    eq(patients.dig(index, :last_name))
+      end
+    end
+
+    it 'does not update outside scoped records' do
+      db_patients = Patient.order(:chart_number).where.not(chart_number: chart_numbers)
+
+      expect(db_patients.count).to eq(1)
+
+      expect(db_patients.first.chart_number).to eq('B0001')
+      expect(db_patients.first.first_name).to   eq('Bugs')
+      expect(db_patients.first.last_name).to    eq('Bunny')
+    end
+
+    it 'outputs total affect row count' do
+      expect(written).to include('Total Rows Affected: 2')
+    end
+
+    context 'when debug is true' do
+      let(:debug) { true }
+
+      it 'outputs sql statements' do
+        expect(written).to include('Update Statement: UPDATE "patients"')
+      end
+
+      it 'outputs return objects' do
+        expect(written).to include('Individual Rows Affected:')
+      end
+    end
+
+    context 'when debug is false' do
+      it 'does not output does sql statements' do
+        expect(written).not_to include('Update Statement: UPDATE "patients"')
+      end
+
+      it 'does not output return objects' do
+        expect(written).not_to include('Individual Rows Affected:')
+      end
+    end
+  end
+end

--- a/spec/db_fuel/library/active_record/update_spec.rb
+++ b/spec/db_fuel/library/active_record/update_spec.rb
@@ -28,7 +28,7 @@ describe DbFuel::Library::ActiveRecord::Update do
         { key: :last_name }
       ],
       table_name: 'patients',
-      unique_keys: [
+      unique_attributes: [
         { key: :chart_number }
       ]
     }
@@ -138,7 +138,7 @@ describe DbFuel::Library::ActiveRecord::Update do
               { key: :last_name }
             ],
             table_name: 'patients',
-            unique_keys: [
+            unique_attributes: [
               { key: :chart_number }
             ]
           }

--- a/spec/db_fuel/library/active_record/update_spec.rb
+++ b/spec/db_fuel/library/active_record/update_spec.rb
@@ -36,17 +36,17 @@ describe DbFuel::Library::ActiveRecord::Update do
 
   let(:patients) do
     [
-      { chart_number: 'C0001', first_name: 'BOZZY', last_name: 'CLOWNZY' },
-      { chart_number: 'R0001', first_name: 'FRANKY', last_name: 'RIZZY' }
+      { 'chart_number' => 'C0001', 'first_name' => 'BOZZY', 'last_name' => 'CLOWNZY' },
+      { 'chart_number' => 'R0001', 'first_name' => 'FRANKY', 'last_name' => 'RIZZY' }
     ]
   end
 
-  let(:chart_numbers) { patients.map { |p| p[:chart_number] } }
+  let(:chart_numbers) { patients.map { |p| p['chart_number'] } }
 
   let(:payload) do
     Burner::Payload.new(
       registers: {
-        register => patients
+        register => patients.map { |p| {}.merge(p) } # shallow copy to preserve original
       }
     )
   end
@@ -61,25 +61,33 @@ describe DbFuel::Library::ActiveRecord::Update do
     end
 
     it 'updates scoped records with specified attributes' do
-      db_patients = Patient.order(:chart_number).where(chart_number: chart_numbers)
+      db_patients = Patient
+                    .order(:chart_number)
+                    .where(chart_number: chart_numbers)
+                    .select(:chart_number, :first_name, :last_name)
+                    .as_json(except: :id)
 
       expect(db_patients.count).to eq(2)
-
-      db_patients.each_with_index do |db_patient, index|
-        expect(db_patient.chart_number).to eq(patients.dig(index, :chart_number))
-        expect(db_patient.first_name).to   eq(patients.dig(index, :first_name))
-        expect(db_patient.last_name).to    eq(patients.dig(index, :last_name))
-      end
+      expect(db_patients).to       eq(patients)
     end
 
     it 'does not update outside scoped records' do
-      db_patients = Patient.order(:chart_number).where.not(chart_number: chart_numbers)
+      db_patients = Patient
+                    .order(:chart_number)
+                    .where.not(chart_number: chart_numbers)
+                    .select(:chart_number, :first_name, :last_name)
+                    .as_json(except: :id)
+
+      expected = [
+        {
+          'chart_number' => 'B0001',
+          'first_name' => 'Bugs',
+          'last_name' => 'Bunny'
+        }
+      ]
 
       expect(db_patients.count).to eq(1)
-
-      expect(db_patients.first.chart_number).to eq('B0001')
-      expect(db_patients.first.first_name).to   eq('Bugs')
-      expect(db_patients.first.last_name).to    eq('Bunny')
+      expect(db_patients).to       eq(expected)
     end
 
     it 'outputs total affect row count' do
@@ -106,6 +114,53 @@ describe DbFuel::Library::ActiveRecord::Update do
       it 'does not output return objects' do
         expect(written).not_to include('Individual Rows Affected:')
       end
+    end
+  end
+
+  describe 'README examples' do
+    specify 'patient update' do
+      pipeline = {
+        jobs: [
+          {
+            name: :load_patients,
+            type: 'b/value/static',
+            register: :patients,
+            value: [
+              { chart_number: 'B0001', last_name: 'Fox' },
+              { chart_number: 'C0001', last_name: 'Smurf' }
+            ]
+          },
+          {
+            name: 'update_patients',
+            type: 'db_fuel/active_record/update',
+            register: :patients,
+            attributes: [
+              { key: :last_name }
+            ],
+            table_name: 'patients',
+            unique_keys: [
+              { key: :chart_number }
+            ]
+          }
+        ]
+      }
+
+      payload = Burner::Payload.new
+
+      Burner::Pipeline.make(pipeline).execute(output: output, payload: payload)
+
+      actual = Patient
+               .order(:chart_number)
+               .select(:chart_number, :first_name, :last_name)
+               .as_json(except: :id)
+
+      expected = [
+        { 'chart_number' => 'B0001', 'first_name' => 'Bugs', 'last_name' => 'Fox' },
+        { 'chart_number' => 'C0001', 'first_name' => 'Bozo', 'last_name' => 'Smurf' },
+        { 'chart_number' => 'R0001', 'first_name' => 'Frank', 'last_name' => 'Rizzo' }
+      ]
+
+      expect(actual).to eq(expected)
     end
   end
 end

--- a/spec/db_fuel/library/dbee/query_spec.rb
+++ b/spec/db_fuel/library/dbee/query_spec.rb
@@ -83,8 +83,7 @@ describe DbFuel::Library::Dbee::Query do
             },
             register: :patients
           }
-        ],
-        steps: %w[retrieve_patients]
+        ]
       }
 
       payload = Burner::Payload.new

--- a/spec/db_fuel/library/dbee/query_spec.rb
+++ b/spec/db_fuel/library/dbee/query_spec.rb
@@ -95,20 +95,19 @@ describe DbFuel::Library::Dbee::Query do
 
       expected = [
         {
-          'id' => 7,
           'first_name' => 'Bozo'
         },
         {
-          'id' => 9,
           'first_name' => 'Bugs'
         },
         {
-          'id' => 8,
           'first_name' => 'Frank'
         }
       ]
 
-      expect(actual).to eq(expected)
+      expect(actual[0]).to include(expected[0])
+      expect(actual[1]).to include(expected[1])
+      expect(actual[2]).to include(expected[2])
     end
   end
 end

--- a/spec/db_fuel/library/dbee/range_spec.rb
+++ b/spec/db_fuel/library/dbee/range_spec.rb
@@ -113,8 +113,7 @@ describe DbFuel::Library::Dbee::Range do
             key: :fname,
             key_path: :first_name
           }
-        ],
-        steps: %w[load_first_names retrieve_patients]
+        ]
       }
 
       payload = Burner::Payload.new

--- a/spec/db_helper.rb
+++ b/spec/db_helper.rb
@@ -54,6 +54,7 @@ def load_data
   inactive_status = Status.create!(code: 'Inactive', priority: 2)
 
   Patient.create!(
+    chart_number: 'C0001',
     first_name: 'Bozo',
     middle_name: 'The',
     last_name: 'Clown',
@@ -61,12 +62,14 @@ def load_data
   )
 
   Patient.create!(
+    chart_number: 'R0001',
     first_name: 'Frank',
     last_name: 'Rizzo',
     status: active_status
   )
 
   Patient.create!(
+    chart_number: 'B0001',
     first_name: 'Bugs',
     middle_name: 'The',
     last_name: 'Bunny',


### PR DESCRIPTION
This PR adds new database-specific jobs:

* db_fuel/active_record/find_or_insert
* db_fuel/active_record/insert
* db_fuel/active_record/update

Future considerations:

* Adding options for how to handle ON DUPLICATE KEY exceptions.
* Performance optimization for bulk inserts, updates, and existence checks.  The initial implementation is going for simplicity an initial test coverage over performance.  Once real world bottlenecks are found we can work to optimize the internals of the jobs dealing with database access.