### PR TITLE
Keys filter for ActiveRecord Jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
+
+# 2.1.0 (May 19th, 2021)
+
+Additions:
+
+* Added keys_register to all db_fuel/active_record jobs.
+
 # 2.0.1 (March 18th, 2021)
 
 Changes:
+
 * Updated attribute_renderer_set to avoid an evaluation time issue with acts_as_hashable.
 
 # 2.0.0 (March 16th, 2021)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Refer to the [Burner](https://github.com/bluemarblepayroll/burner) library for m
 
 ### ActiveRecord Jobs
 
-* **db_fuel/active_record/find_or_insert** [name, table_name, attributes, debug, primary_keyed_column, register, separator, timestamps, unique_attributes]: An extension of the `db_fuel/active_record/insert` job that adds an existence check before SQL insertion. The  `unique_attributes` will be converted to WHERE clauses for performing the existence check.
-* **db_fuel/active_record/insert** [name, table_name, attributes, debug, primary_keyed_column, register, separator, timestamps]: This job can take the objects in a register and insert them into a database table.  If primary_keyed_column is specified then its key will be set to the primary key.  Note that composite primary keys are not supported.  Attributes defines which object properties to convert to SQL.  Refer to the class and constructor specification for more detail.
-* **db_fuel/active_record/update_all** [name, table_name, attributes, debug, register, separator, timestamps, unique_attributes]: This job can take the objects in a register and updates them within a database table.  Attributes defines which object properties to convert to SQL SET clauses while unique_attributes translate to WHERE clauses. One or more records may be updated at a time.  Refer to the class and constructor specification for more detail.
-* **db_fuel/active_record/update** [name, table_name, attributes, debug, register, primary_keyed_column, separator, timestamps, unique_attributes]: This job can take the unique objects in a register and updates them within a database table.  Attributes defines which object properties to convert to SQL SET clauses while unique_attributes translate to WHERE clauses to find the records to update. The primary_keyed_column is used to update the unique record. Only one record will be updated per statement. Note that composite primary keys are not supported.  Refer to the class and constructor specification for more detail.
-* **db_fuel/active_record/upsert** [name, table_name, attributes, debug, primary_keyed_column, register, separator, timestamps, unique_attributes]: This job can take the objects in a register and either inserts or updates them within a database table.  Attributes defines which object properties to convert to SQL SET clauses while each key in unique_attributes become a WHERE clause in order to check for the existence of a specific record. The updated record will use the primary_keyed_column specified to perform the UPDATE operation. Note that composite primary keys are not supported. Refer to the class and constructor specification for more detail.
+* **db_fuel/active_record/find_or_insert** [name, table_name, attributes, debug, primary_keyed_column, keys_register, register, separator, timestamps, unique_attributes]: An extension of the `db_fuel/active_record/insert` job that adds an existence check before SQL insertion. The  `unique_attributes` will be converted to WHERE clauses for performing the existence check.
+* **db_fuel/active_record/insert** [name, table_name, attributes, debug, primary_keyed_column, keys_register, register, separator, timestamps]: This job can take the objects in a register and insert them into a database table.  If primary_keyed_column is specified then its key will be set to the primary key.  Note that composite primary keys are not supported.  Attributes defines which object properties to convert to SQL.  Refer to the class and constructor specification for more detail.
+* **db_fuel/active_record/update_all** [name, table_name, attributes, debug, keys_register, register, separator, timestamps, unique_attributes]: This job can take the objects in a register and updates them within a database table.  Attributes defines which object properties to convert to SQL SET clauses while unique_attributes translate to WHERE clauses. One or more records may be updated at a time.  Refer to the class and constructor specification for more detail.
+* **db_fuel/active_record/update** [name, table_name, attributes, debug, keys_register, register, primary_keyed_column, separator, timestamps, unique_attributes]: This job can take the unique objects in a register and updates them within a database table.  Attributes defines which object properties to convert to SQL SET clauses while unique_attributes translate to WHERE clauses to find the records to update. The primary_keyed_column is used to update the unique record. Only one record will be updated per statement. Note that composite primary keys are not supported.  Refer to the class and constructor specification for more detail.
+* **db_fuel/active_record/upsert** [name, table_name, attributes, debug, primary_keyed_column, keys_register, register, separator, timestamps, unique_attributes]: This job can take the objects in a register and either inserts or updates them within a database table.  Attributes defines which object properties to convert to SQL SET clauses while each key in unique_attributes become a WHERE clause in order to check for the existence of a specific record. The updated record will use the primary_keyed_column specified to perform the UPDATE operation. Note that composite primary keys are not supported. Refer to the class and constructor specification for more detail.
 
 ### Dbee Jobs
 
@@ -331,7 +331,7 @@ Each database record should have been updated with their new respective middle n
 
 #### Upserting Records
 
-Let's say we don't know if these chart_number values already exist or not. 
+Let's say we don't know if these chart_number values already exist or not.
 So we want db_fuel to either insert a record if the chart_number doesn't exist or update the record if the chart_number already exists.
 
 ````ruby
@@ -378,6 +378,10 @@ Notes:
 
 * The `unique_attributes` translate to WHERE clauses.
 * Set `debug: true` to print out each UPDATE statement in the output (not for production use.)
+
+#### Limiting The Columns Being Inserted/Updated
+
+All the db_fuel/active_record/* jobs now feature an optional `keys_register` option.  If this is set, the register will be read and used as a key filter for which fields to set.  For example, if you configure a db_fuel/active_record/insert job to update A, B, C, and D, but your keys_register contains [A,B] then only A and B will be inserted/set.  This is helpful in scenarios where you may want to outline how to update _all_ possible fields but your input set only contains a subset of those fields and you do not wish to set the others to null.
 ## Contributing
 
 ### Development Environment Configuration

--- a/lib/db_fuel/library/active_record/base.rb
+++ b/lib/db_fuel/library/active_record/base.rb
@@ -22,6 +22,7 @@ module DbFuel
         attr_reader :attribute_renderers,
                     :db_provider,
                     :debug,
+                    :keys_register,
                     :resolver,
                     :attribute_renderers_set
 
@@ -30,12 +31,14 @@ module DbFuel
           name: '',
           attributes: [],
           debug: false,
+          keys_register: nil,
           register: Burner::DEFAULT_REGISTER,
           separator: ''
         )
           super(name: name, register: register)
 
-          @resolver = Objectable.resolver(separator: separator)
+          @keys_register           = keys_register.to_s
+          @resolver                = Objectable.resolver(separator: separator)
           @attribute_renderers_set = Modeling::AttributeRendererSet.new(resolver: resolver,
                                                                         attributes: attributes)
           @db_provider = DbProvider.new(table_name)
@@ -48,6 +51,16 @@ module DbFuel
           return unless debug
 
           output.detail(message)
+        end
+
+        def resolve_key_set(output, payload)
+          return Set.new if keys_register.empty?
+
+          keys = array(payload[keys_register]).map(&:to_s).to_set
+
+          output.detail("Limiting to only keys: #{keys.to_a.join(', ')}") if keys.any?
+
+          keys
         end
       end
     end

--- a/lib/db_fuel/library/active_record/find_or_insert.rb
+++ b/lib/db_fuel/library/active_record/find_or_insert.rb
@@ -57,6 +57,7 @@ module DbFuel
           name: '',
           attributes: [],
           debug: false,
+          keys_register: nil,
           primary_keyed_column: nil,
           register: Burner::DEFAULT_REGISTER,
           separator: '',
@@ -66,6 +67,7 @@ module DbFuel
 
           super(
             name: name,
+            keys_register: keys_register,
             table_name: table_name,
             attributes: attributes,
             debug: debug,
@@ -82,6 +84,7 @@ module DbFuel
           total_existed  = 0
 
           payload[register] = array(payload[register])
+          keys              = resolve_key_set(output, payload)
 
           payload[register].each do |row|
             exists = find_record(output, row, payload.time)
@@ -91,7 +94,7 @@ module DbFuel
               next
             end
 
-            insert_record(output, row, payload.time)
+            insert_record(output, row, payload.time, keys)
 
             total_inserted += 1
           end

--- a/lib/db_fuel/library/active_record/insert.rb
+++ b/lib/db_fuel/library/active_record/insert.rb
@@ -45,6 +45,7 @@ module DbFuel
         #               to the current UTC timestamp.
         def initialize(
           table_name:,
+          keys_register: nil,
           name: '',
           attributes: [],
           debug: false,
@@ -53,11 +54,11 @@ module DbFuel
           separator: '',
           timestamps: true
         )
-
           attributes = Burner::Modeling::Attribute.array(attributes)
 
           super(
             name: name,
+            keys_register: keys_register,
             table_name: table_name,
             attributes: attributes,
             debug: debug,
@@ -70,8 +71,11 @@ module DbFuel
 
         def perform(output, payload)
           payload[register] = array(payload[register])
+          keys              = resolve_key_set(output, payload)
 
-          payload[register].each { |row| insert_record(output, row, payload.time) }
+          output.detail("Inserting #{payload[register].count} record(s)")
+
+          payload[register].each { |row| insert_record(output, row, payload.time, keys) }
         end
       end
     end

--- a/lib/db_fuel/library/active_record/upsert.rb
+++ b/lib/db_fuel/library/active_record/upsert.rb
@@ -59,6 +59,7 @@ module DbFuel
         def initialize(
           table_name:,
           primary_keyed_column:,
+          keys_register: nil,
           name: '',
           attributes: [],
           debug: false,
@@ -69,6 +70,7 @@ module DbFuel
         )
           super(
             name: name,
+            keys_register: keys_register,
             table_name: table_name,
             attributes: attributes,
             debug: debug,
@@ -128,7 +130,7 @@ module DbFuel
           first_record
         end
 
-        def insert_record(output, row, time)
+        def insert_record(output, row, time, keys = Set.new)
           dynamic_attrs = if timestamps
                             # doing an INSERT and timestamps should be set
                             # set the created_at and updated_at fields
@@ -137,7 +139,7 @@ module DbFuel
                             attribute_renderers_set.attribute_renderers
                           end
 
-          set_object = attribute_renderers_set.transform(dynamic_attrs, row, time)
+          set_object = attribute_renderers_set.transform(dynamic_attrs, row, time, keys)
 
           insert_sql = db_provider.insert_sql(set_object)
 

--- a/lib/db_fuel/modeling/attribute_renderer_set.rb
+++ b/lib/db_fuel/modeling/attribute_renderer_set.rb
@@ -52,8 +52,10 @@ module DbFuel
           .map { |a| Burner::Modeling::AttributeRenderer.new(a, resolver) }
       end
 
-      def transform(attribute_renderers, row, time)
+      def transform(attribute_renderers, row, time, keys = Set.new)
         attribute_renderers.each_with_object({}) do |attribute_renderer, memo|
+          next if keys.any? && keys.exclude?(attribute_renderer.key)
+
           value = attribute_renderer.transform(row, time)
 
           resolver.set(memo, attribute_renderer.key, value)

--- a/lib/db_fuel/version.rb
+++ b/lib/db_fuel/version.rb
@@ -8,5 +8,5 @@
 #
 
 module DbFuel
-  VERSION = '2.0.1'
+  VERSION = '2.1.0'
 end

--- a/spec/db_fuel/library/active_record/update_spec.rb
+++ b/spec/db_fuel/library/active_record/update_spec.rb
@@ -14,14 +14,17 @@ describe DbFuel::Library::ActiveRecord::Update do
     load_data
   end
 
-  let(:output)   { make_burner_output }
-  let(:register) { 'register_a' }
-  let(:debug)    { false }
+  let(:output)        { make_burner_output }
+  let(:register)      { 'register_a' }
+  let(:debug)         { false }
+  let(:keys_register) { 'register_for_keys' }
+  let(:keys)          { [] }
 
   let(:config) do
     {
       name: 'test_job',
       register: register,
+      keys_register: keys_register,
       debug: debug,
       attributes: [
         { key: :first_name },
@@ -47,6 +50,7 @@ describe DbFuel::Library::ActiveRecord::Update do
   let(:payload) do
     Burner::Payload.new(
       registers: {
+        keys_register => keys,
         register => patients.map { |p| {}.merge(p) } # shallow copy to preserve original
       }
     )
@@ -114,6 +118,29 @@ describe DbFuel::Library::ActiveRecord::Update do
 
       it 'does not output return objects' do
         expect(written).not_to include('Individual Rows Affected:')
+      end
+    end
+
+    context 'when keys_register has at least one key' do
+      let(:keys) { %w[chart_number first_name] }
+
+      it 'outputs list of keys' do
+        expect(written).to include("keys: #{keys.join(', ')}")
+      end
+
+      it 'only updates keys in keys_register' do
+        actual = Patient
+                 .order(:chart_number)
+                 .select(:chart_number, :first_name, :last_name)
+                 .as_json(except: :id)
+
+        expected = [
+          { 'chart_number' => 'B0001', 'first_name' => 'Bugs', 'last_name' => 'Bunny' },
+          { 'chart_number' => 'C0001', 'first_name' => 'BOZZY', 'last_name' => 'Clown' },
+          { 'chart_number' => 'R0001', 'first_name' => 'FRANKY', 'last_name' => 'Rizzo' }
+        ]
+
+        expect(actual).to match(expected)
       end
     end
   end


### PR DESCRIPTION
This PR adds a new option to all db_fuel/active_record/* jobs: `keys_register`. If this register is populated then the keys listed will be the only columns updated in the INSERT and UPDATE statements.  Note that this does not affect finding/identifying records.